### PR TITLE
Jenkinsfile: Set SKIP_GIT_CLEANUP=true

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
       steps {
         git 'https://git.merproject.org/mer-core/libglibutil.git'
         sh '''
+        export SKIP_GIT_CLEANUP=true
         sed -i -e '0,/unstable/ s//xenial/' debian/changelog
         /usr/bin/build-source.sh
         '''


### PR DESCRIPTION
Make sure the sed changes don't get reverted by generate-git-snapshot.

This will also pull in a newer version of libglibutil (1.0.51 as of Mar 15th 2021).